### PR TITLE
chore: update Stainless workflow to use PR-based SDK builds

### DIFF
--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -1,17 +1,59 @@
-name: Upload OpenAPI spec to Stainless
+name: Build SDKs for pull request
+
+env:
+  OAS_PATH: ./openapi.yaml
+  STAINLESS_ORG: sully-ai
+  STAINLESS_PROJECT: sullyai-api
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  stainless:
-    concurrency: upload-openapi-spec-action
+  preview:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: stainless-api/upload-openapi-spec-action@main
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
-          input_path: 'openapi.yaml'
+          fetch-depth: 2
+
+      - name: Run preview builds
+        uses: stainless-api/upload-openapi-spec-action/preview@v1
+        with:
+          org: ${{ env.STAINLESS_ORG }}
+          project: ${{ env.STAINLESS_PROJECT }}
+          oas_path: ${{ env.OAS_PATH }}
+
+  merge:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Run merge build
+        uses: stainless-api/upload-openapi-spec-action/merge@v1
+        with:
+          org: ${{ env.STAINLESS_ORG }}
+          project: ${{ env.STAINLESS_PROJECT }}
+          oas_path: ${{ env.OAS_PATH }}


### PR DESCRIPTION
## Summary
- Replaces push-based workflow with PR-driven approach for SDK builds
- Adds preview builds on PR open/sync/reopen events
- Adds merge builds when PRs are merged to main
- Uses OIDC authentication instead of API key secrets
- Adds concurrency controls to cancel in-progress builds

## Test plan
- [ ] Verify preview build runs on PR creation
- [ ] Verify merge build triggers when PR is merged