### PR TITLE
feat: require noteType in Create Note payload

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -734,6 +734,7 @@ components:
       type: object
       required:
         - transcript
+        - noteType
       properties:
         transcript:
           type: string


### PR DESCRIPTION
## Summary

- Require `noteType` in `CreateNotePayload` for `POST /v1/notes`.
- Align the public OpenAPI contract with the API server's current validation behavior.
- Preserve the documented default of `soap` for `noteType.type` when the object is supplied without `type`.

## Verification

- Ruby YAML semantic assertion: `CreateNotePayload.required` includes `noteType` — passed.
- Calibrated negative/positive assertion: base spec lacked `noteType`; changed spec requires it — passed.
- `redocly lint openapi.yaml`: existing baseline failures remain unchanged (5 errors, 7 warnings); no new diagnostics from this one-line change.
- `git diff --check`: passed.

## Scope

This updates the public contract only. Runtime API behavior is already stricter; the corresponding API-server compatibility fix is tracked separately.
